### PR TITLE
Travis CI: Add syntax error tests on Python 2 & 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,23 @@
 language: cpp
-compiler:
- - clang
+matrix:
+  include:
+    - os: linux
+      compiler: clang
+    - os: osx
+      compiler: clang
+    - python: 2.7
+      language: python
+      before_install: pip install flake8
+      script: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    - python: 3.7
+      language: python
+      before_install: pip install flake8
+      script: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+      dist: xenial # required for Python >= 3.7 (travis-ci/travis-ci#9069)
+
 before_install: ./buildbot/travis-checkout.sh
 script: ./buildbot/travis-test.sh
-os:
-  - linux
-  - osx
+
 branches:
   only:
   - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,4 @@ script: ./buildbot/travis-test.sh
 branches:
   only:
   - master
+ 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
       language: python
       before_install: pip install flake8
       script: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
-      dist: xenial # required for Python >= 3.7 (travis-ci/travis-ci#9069) 
+      dist: xenial # required for Python >= 3.7 (travis-ci/travis-ci#9069)
 
 before_install: ./buildbot/travis-checkout.sh
 script: ./buildbot/travis-test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
       language: python
       before_install: pip install flake8
       script: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
-      dist: xenial # required for Python >= 3.7 (travis-ci/travis-ci#9069)
+      dist: xenial # required for Python >= 3.7 (travis-ci/travis-ci#9069) 
 
 before_install: ./buildbot/travis-checkout.sh
 script: ./buildbot/travis-test.sh


### PR DESCRIPTION
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree

@dpranke @sgraham Output is: https://travis-ci.org/chromium/gyp/builds/464221582